### PR TITLE
Support endianness on GNU/Hurd

### DIFF
--- a/include/savvy/portable_endian.hpp
+++ b/include/savvy/portable_endian.hpp
@@ -13,7 +13,7 @@
 
 #endif
 
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__)
 
 # include <endian.h>
 


### PR DESCRIPTION
Since it is based on GNU libc, it has <endian.h> as already used on e.g. Linux.